### PR TITLE
fix url of store_agent in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,4 +52,4 @@ group :test do
   gem "timecop"
 end
 
-gem "store_agent", git: "git@github.com:realglobe-Inc/store_agent.git"
+gem "store_agent", git: "https://github.com/realglobe-Inc/store_agent.git"


### PR DESCRIPTION
Fix error related to ssh key problem.
For more details, please follow the link below.

Fail: Permission denied from GitHub on bundle install
https://semaphoreci.com/docs/fail-permission-denied-from-github.html
